### PR TITLE
retry for _get

### DIFF
--- a/pynio/rest.py
+++ b/pynio/rest.py
@@ -12,14 +12,25 @@ class REST(object):
         self._creds = creds or ('User', 'User')
         self._url = 'http://{}:{}/{}'.format(host, port, '{}')
 
-    def _get(self, endpoint, timeout=None, data=None):
+    def _get(self, endpoint, timeout=None, data=None, retry=0):
+        '''Performs a get with some amounts of retrys'''
         if data is not None:
             data = json.dumps(data)
-        r = requests.get(self._url.format(endpoint),
-                         auth=self._creds,
-                         timeout=timeout,
-                         data=data)
-        r.raise_for_status()
+        for i in range(retry + 1):
+            try:
+                r = requests.get(self._url.format(endpoint),
+                                 auth=self._creds,
+                                 timeout=timeout,
+                                 data=data)
+                r.raise_for_status()
+                break
+            except requests.exceptions.ConnectionError as e:
+                log.warning("Failure connecting in _get")
+                E = e
+                if i < retry:
+                    time.sleep(1)
+        else:
+            raise E
         return r.json()
 
     def _put(self, endpoint, config=None, timeout=None):

--- a/pynio/rest.py
+++ b/pynio/rest.py
@@ -1,5 +1,10 @@
-import requests
+import logging
 import json
+import time
+
+import requests
+
+log = logging.getLogger(__name__)
 
 
 class REST(object):

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -67,11 +67,11 @@ class TestREST(unittest.TestCase):
     @patch('requests.get')
     def test_raise_wrong(self, get, sleep):
         raise_count = 1
-        raises = iter_raise(NameError,
+        raises = iter_raise(ZeroDivisionError,
                             raise_count, None)
         response = mock_response()
         response.raise_for_status = lambda: next(raises)
         get.return_value = response
         r = rest.REST()
-        with self.assertRaises(NameError):
+        with self.assertRaises(ZeroDivisionError):
             r._get('end', retry=raise_count)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from pynio import rest
+
+
+def mock_response():
+    response = MagicMock(spec=['json', 'raise_for_status'])
+    response.json = MagicMock()
+    # response.raise_for_status = MagicMock()
+    return response
+
+
+class iter_raise:
+    def __init__(self, error, times, return_val):
+        self.error = error
+        self.times = times
+        self.count = 0
+        self.return_val = return_val
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.count < self.times:
+            self.count += 1
+            raise self.error
+        return self.return_val
+
+
+class TestREST(unittest.TestCase):
+    @patch('requests.get')
+    def test_get(self, get):
+        response = mock_response()
+        get.return_value = response
+        r = rest.REST()
+        r._get('end')
+        self.assertTrue(get.called)
+        self.assertTrue(response.json.called)
+        self.assertTrue(response.raise_for_status.called)
+        self.assertEqual(get.call_args[0][0], 'http://127.0.0.1:8181/end')
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_get_retry(self, get, sleep):
+        raise_count = 4
+        raises = iter_raise(requests.exceptions.ConnectionError,
+                            raise_count, None)
+        response = mock_response()
+        response.raise_for_status = lambda: next(raises)
+        get.return_value = response
+        r = rest.REST()
+        r._get('end', retry=raise_count)
+        self.assertTrue(get.called)
+        self.assertTrue(response.json.called)
+        self.assertEqual(get.call_args[0][0], 'http://127.0.0.1:8181/end')
+        self.assertEqual(sleep.call_count, raise_count)
+
+        # make sure it fails when we retry too much
+        raises.count = 0
+        with self.assertRaises(requests.exceptions.ConnectionError):
+            r._get('end', retry=raise_count - 1)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -58,7 +58,7 @@ class TestREST(unittest.TestCase):
         self.assertEqual(get.call_args[0][0], 'http://127.0.0.1:8181/end')
         self.assertEqual(sleep.call_count, raise_count)
 
-        # make sure it fails when we retry too much
+        # make sure it fails when we don't retry enough
         raises.count = 0
         with self.assertRaises(requests.exceptions.ConnectionError):
             r._get('end', retry=raise_count - 1)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -62,3 +62,16 @@ class TestREST(unittest.TestCase):
         raises.count = 0
         with self.assertRaises(requests.exceptions.ConnectionError):
             r._get('end', retry=raise_count - 1)
+
+    @patch('time.sleep')
+    @patch('requests.get')
+    def test_raise_wrong(self, get, sleep):
+        raise_count = 1
+        raises = iter_raise(NameError,
+                            raise_count, None)
+        response = mock_response()
+        response.raise_for_status = lambda: next(raises)
+        get.return_value = response
+        r = rest.REST()
+        with self.assertRaises(NameError):
+            r._get('end', retry=raise_count)


### PR DESCRIPTION
In case you are curious, [vim-futigive](https://github.com/tpope/vim-fugitive) makes the process of selecting specific lines from commits very easy. You just open a file and do `:Gdiff BRANCH` and it opens a vim diff with the two branches. You then use `do` and `dp` to move data between the two branches.