### PR TITLE
F/properties

### DIFF
--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -358,6 +358,8 @@ class TypedEnum:
         return self._value.name
 
     def __set__(self, obj, value):
+        if hasattr(value, '__get__'):
+            value = value.__get__(None, None)
         self.value = value
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -123,6 +123,15 @@ class TestTypedEnum(unittest.TestCase):
         venum.__set__(None, 1)
         self.assertEqual(venum.__get__(None, None), 'b')
 
+    def test_setting_enum(self):
+        '''enum should be able to be set with another enum object'''
+        venum = TypedEnum(abc)
+        venum2 = TypedEnum(abc)
+        venum2.__set__(None, 'b')
+        venum.__set__(None, venum2)
+        self.assertEqual(venum.value, venum2.value)
+        self.assertEqual(venum.value, 1)
+
 
 template = {
     'name': 'template',


### PR DESCRIPTION
`TypedEnum` needs to work when it is being set from another `TypedEnum`. This is done through using that values `__get__` method, so that it can be general.