### PR TITLE
F/remove block

### DIFF
--- a/pynio/block.py
+++ b/pynio/block.py
@@ -104,7 +104,7 @@ class Block(object):
         '''Delete self from instance and services'''
         self._instance._delete('blocks/{}'.format(self._name))
         for s in self._instance.services.values():
-            s._remove(self)
+            s.remove_block(self)
         self._instance.blocks.pop(self._name)
         self._instance = None  # make sure it isn't used anymore
 

--- a/pynio/service.py
+++ b/pynio/service.py
@@ -58,7 +58,7 @@ class Service(object):
             connection = {'name': blk1.name, 'receivers': receivers}
             execution.append(connection)
 
-    def _remove(self, block):
+    def remove_block(self, block):
         '''remove a block from service. Does NOT delete the block'''
         execution = self.config.get('execution', None)
         if execution is None:  # no blocks

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -37,7 +37,6 @@ def mock_instance(type=template):
         'config', 'droplog',
         'blocks', 'blocks_types', 'services',
         '_put'])()
-    # instance.__init__ = MagicMock()
     instance.droplog = MagicMock()
     instance._put = MagicMock()
     instance._get = MagicMock()

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock
-from pynio import properties, Block
+from pynio import properties, Block, Instance
 
 template = {
     'name': 'template',
@@ -27,14 +27,23 @@ config = {
 }
 
 
+class _Instance(Instance):
+    def __init__(self):
+        pass
+
+
 def mock_instance(type=template):
-    instance = MagicMock(spec=[
+    instance = MagicMock(wraps=_Instance, spec=[
         'config', 'droplog',
         'blocks', 'blocks_types', 'services',
-        '_put'])
+        '_put'])()
+    # instance.__init__ = MagicMock()
     instance.droplog = MagicMock()
     instance._put = MagicMock()
+    instance._get = MagicMock()
+    instance._delete = MagicMock()
     instance.blocks = {}
+    instance.services = {}
     b = Block('type', 'type', instance=instance)
     b._load_template('type', template)
     instance.blocks_types = {

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -8,123 +8,122 @@ from .mock import mock_instance, config, template
 
 class TestBlock(unittest.TestCase):
 
-        def test_block(self):
-            b = Block('name', 'type')
-            self.assertEqual(b.name, 'name')
-            self.assertEqual(b.type, 'type')
+    def test_block(self):
+        b = Block('name', 'type')
+        self.assertEqual(b.name, 'name')
+        self.assertEqual(b.type, 'type')
 
-        def test_noname(self):
-            with self.assertRaises(ValueError):
-                Block('', 'type')
+    def test_noname(self):
+        with self.assertRaises(ValueError):
+            Block('', 'type')
 
-        def test_save(self):
-            b = Block('name', 'type', config)
-            b._instance = mock_instance()
-            b._put = MagicMock()
+    def test_save(self):
+        b = Block('name', 'type', config)
+        b._instance = mock_instance()
+        b._put = MagicMock()
+        b.save()
+        self.assertTrue(b._put.called)
+        self.assertEqual(b._put.call_args[0][0], 'blocks/name')
+        self.assertDictEqual(b._put.call_args[0][1],
+                                {'name': 'name',
+                                'type': 'type',
+                                'value': 0})
+
+    def test_copy(self):
+        b = Block('name', 'type', {'key': 'value'})
+        bcopy = b.copy('newname')
+        self.assertDictEqual({
+            'name': 'newname',
+            'type': 'type',
+            'key': 'value'
+        }, bcopy.config)
+        self.assertDictEqual({
+            'name': 'name',
+            'type': 'type',
+            'key': 'value'
+        }, b.config)
+
+        with self.assertRaises(ValueError):
+            b.copy('')
+
+    def test_save_with_no_instance(self):
+        b = Block('name', 'type')
+        b._config = {'key': 'val'}
+        b._put = MagicMock()
+        with self.assertRaises(Exception) as context:
             b.save()
-            self.assertTrue(b._put.called)
-            self.assertEqual(b._put.call_args[0][0], 'blocks/name')
-            self.assertDictEqual(b._put.call_args[0][1],
-                                 {'name': 'name',
-                                  'type': 'type',
-                                  'value': 0})
+        self.assertTrue('Block is not associated with an instance' in
+                        context.exception.args[0])
+        self.assertFalse(b._put.called)
 
-        def test_copy(self):
-            b = Block('name', 'type', {'key': 'value'})
-            bcopy = b.copy('newname')
-            self.assertDictEqual({
-                'name': 'newname',
-                'type': 'type',
-                'key': 'value'
-            }, bcopy.config)
-            self.assertDictEqual({
-                'name': 'name',
-                'type': 'type',
-                'key': 'value'
-            }, b.config)
+    def test_load_template(self):
+        from .example_data import SimulatorFastTemplate
+        instance = lambda: None
+        instance.droplog = print
+        btype = 'SimulatorFast'
+        b = Block('sim', btype)
+        b._load_template(btype, SimulatorFastTemplate, instance)
+        from pprint import pprint
+        print()
+        pprint(b.template)
+        self.assertRaises(TypeError, setattr, b.template, 'type', 'foo')
 
-            with self.assertRaises(ValueError):
-                b.copy('')
+    def test_typed_config(self):
+        from .example_data import SimulatorFastTemplate, SimulatorFastConfig
+        instance = lambda: None
+        instance.droplog = print
+        btype = 'SimulatorFast'
+        b = Block('sim', btype, config=SimulatorFastConfig)
+        b._load_template(btype, SimulatorFastTemplate, instance)
+        b.config.interval.days = 10
+        self.assertEqual(b.config.interval.days, 10)
+        self.assertRaises(ValueError, setattr,
+                            b.config.interval, 'days', 'bad')
 
-        def test_save_with_no_instance(self):
-            b = Block('name', 'type')
-            b._config = {'key': 'val'}
-            b._put = MagicMock()
-            with self.assertRaises(Exception) as context:
-                b.save()
-            self.assertTrue('Block is not associated with an instance' in
-                            context.exception.args[0])
-            self.assertFalse(b._put.called)
+    def test_load_config(self):
+        instance = mock_instance()
+        b = Block('name', 'type', config, instance=instance)
+        b.save()
+        self.assertDictEqual(b.json(), config)
+        self.assertTrue(instance._put.called)
 
-        def test_load_template(self):
-            from .example_data import SimulatorFastTemplate
-            instance = lambda: None
-            instance.droplog = print
-            btype = 'SimulatorFast'
-            b = Block('sim', btype)
-            b._load_template(btype, SimulatorFastTemplate, instance)
-            from pprint import pprint
-            print()
-            pprint(b.template)
-            self.assertRaises(TypeError, setattr, b.template, 'type', 'foo')
+    def test_config_drop(self):
+        '''Ensure it drops non-existant settings'''
+        c = deepcopy(config)
+        c['notthere'] = 4
+        instance = mock_instance()
+        b = Block('name', 'type', c, instance=instance)
+        b.save()
+        self.assertDictEqual(b.json(), config)
+        self.assertTrue(instance._put.called)
 
-        def test_typed_config(self):
-            from .example_data import SimulatorFastTemplate, SimulatorFastConfig
-            instance = lambda: None
-            instance.droplog = print
-            btype = 'SimulatorFast'
-            b = Block('sim', btype, config=SimulatorFastConfig)
-            b._load_template(btype, SimulatorFastTemplate, instance)
-            b.config.interval.days = 10
-            self.assertEqual(b.config.interval.days, 10)
-            self.assertRaises(ValueError, setattr,
-                              b.config.interval, 'days', 'bad')
-
-        def test_load_config(self):
-            instance = mock_instance()
-            b = Block('name', 'type', config, instance=instance)
-            b.save()
-            self.assertDictEqual(b.json(), config)
-            self.assertTrue(instance._put.called)
-
-        def test_config_drop(self):
-            '''Ensure it drops non-existant settings'''
-            c = deepcopy(config)
-            c['notthere'] = 4
-            instance = mock_instance()
-            b = Block('name', 'type', c, instance=instance)
-            b.save()
-            self.assertDictEqual(b.json(), config)
-            self.assertTrue(instance._put.called)
-
-        def test_load_all_templates(self):
-            from .example_data import BlocksTemplatesAll
-            instance = lambda: None
-            instance.droplog = MagicMock()
-            for btype, template in BlocksTemplatesAll.items():
-                b = Block(btype, btype)
-                b._load_template(btype, template, instance)
+    def test_load_all_templates(self):
+        from .example_data import BlocksTemplatesAll
+        instance = lambda: None
+        instance.droplog = MagicMock()
+        for btype, template in BlocksTemplatesAll.items():
+            b = Block(btype, btype)
+            b._load_template(btype, template, instance)
 
 
-        def test_load_all_configs(self):
-            from .example_data import BlocksTemplatesAll, BlocksConfigsAll
-            instance = lambda: None
-            instance.droplog = MagicMock()
+    def test_load_all_configs(self):
+        from .example_data import BlocksTemplatesAll, BlocksConfigsAll
+        instance = lambda: None
+        instance.droplog = MagicMock()
 
-            blocks_types = {}
-            for btype, template in BlocksTemplatesAll.items():
-                b = Block(btype, btype)
-                b._load_template(btype, template, instance)
-                blocks_types[btype] = b
+        blocks_types = {}
+        for btype, template in BlocksTemplatesAll.items():
+            b = Block(btype, btype)
+            b._load_template(btype, template, instance)
+            blocks_types[btype] = b
 
-            blocks = {}
-            for bname, config in BlocksConfigsAll.items():
-                # import ipdb; ipdb.set_trace()
-                btype = config['type']
-                b = deepcopy(blocks_types[btype])
-                b.config = config
-                blocks[bname] = b
+        blocks = {}
+        for bname, config in BlocksConfigsAll.items():
+            # import ipdb; ipdb.set_trace()
+            btype = config['type']
+            b = deepcopy(blocks_types[btype])
+            b.config = config
+            blocks[bname] = b
 
-            droplog = instance.droplog
-            self.assertEqual(droplog.call_count, 2)
-
+        droplog = instance.droplog
+        self.assertEqual(droplog.call_count, 2)

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -127,3 +127,15 @@ class TestBlock(unittest.TestCase):
 
         droplog = instance.droplog
         self.assertEqual(droplog.call_count, 2)
+
+    def test_delete_block(self):
+        instance = mock_instance()
+        s = instance.create_service('foo')
+        b = s.create_block('one', 'type')
+        b2 = s.create_block('two', 'type')
+        s.connect(b, b2)
+        b.delete()
+        execution = s.config['execution']
+        self.assertListEqual(execution, [
+            {'name': 'two', 'receivers': []}
+        ])

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -130,3 +130,13 @@ class TestService(unittest.TestCase):
         self.assertTrue(mm.called)
         self.assertEqual(mm.call_args[0][0],
                          'services/{}/{}/{}'.format('name', 'one', 'bar'))
+
+    def test_remove_block(self):
+        s = Service('name')
+        blk = TestBlock('one')
+        s.connect(blk, TestBlock('two'))
+        s.remove_block(blk)
+        execution = s.config['execution']
+        self.assertListEqual(execution, [
+            {'name': 'two', 'receivers': []}
+        ])


### PR DESCRIPTION
- renamed `Service._remove` to `Service.remove_block`
- added unit tests for removing and deleting blocks
- fixes #30 