### PR TITLE
B/properties

### DIFF
--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -437,7 +437,7 @@ def load_list(template):
         except TypeError: isin = False
         if isin:
             tp['type'] = tp.pop('template')
-            tp.pop('default')
+            tp.pop('default', None)
             gettype = True
         else:
             tp['type'] = 'object'

--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -429,20 +429,21 @@ def load_list(template):
     '''Specifically used for the "list" type'''
     tp = dict(template)
     default = template.get('default', [])
+    isbase = False
     if 'type' not in template:
         # Lists have an interesting feature where they assume you know
         # their attributes are objects or the type
         # specified in their template if they don't have a type
-        try: isin = tp['template'] in {'bool', 'str', 'int', 'float'}
-        except TypeError: isin = False
-        if isin:
+        try: isbase = tp['template'] in {'bool', 'str', 'int', 'float'}
+        except TypeError: isbase = False
+        if isbase:
             tp['type'] = tp.pop('template')
-            gettype = True
+            # The default won't make sense since it is a list of values
+            tp.pop('default', None)
         else:
             tp['type'] = 'object'
-            gettype = False
     t = load_template(tp)
-    if gettype:
+    if isbase:
         t = type(t)
     return TypedList(t, default)
 

--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -427,13 +427,25 @@ def load_template(template):
 
 def load_list(template):
     '''Specifically used for the "list" type'''
+    tp = dict(template)
     default = template.get('default', [])
     if 'type' not in template:
         # Lists have an interesting feature where they assume you know
-        # their attributes are objects if they don't have a type
-        template['type'] = 'object'
-    template = load_template(template)
-    return TypedList(template, default)
+        # their attributes are objects or the type
+        # specified in their template if they don't have a type
+        try: isin = tp['template'] in {'bool', 'str', 'int', 'float'}
+        except TypeError: isin = False
+        if isin:
+            tp['type'] = tp.pop('template')
+            tp.pop('default')
+            gettype = True
+        else:
+            tp['type'] = 'object'
+            gettype = False
+    t = load_template(tp)
+    if gettype:
+        t = type(t)
+    return TypedList(t, default)
 
 
 # Define all the properties and how to load them when you get their dict

--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -437,7 +437,6 @@ def load_list(template):
         except TypeError: isin = False
         if isin:
             tp['type'] = tp.pop('template')
-            tp.pop('default', None)
             gettype = True
         else:
             tp['type'] = 'object'

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -217,6 +217,7 @@ class TestLoadProperties(unittest.TestCase):
         blk.update(c)
         self.assertEqual(blk.__basic__(), c)
 
+        # import ipdb; ipdb.set_trace()
         t['properties']['attributes']['default'] = default
         blk = load_block(t, 'type')
         blk.name = 'name'

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -191,7 +191,29 @@ class TestLoadProperties(unittest.TestCase):
 
         c['attributes'].extend(default)
         # make sure that the object updates properly
-        # import ipdb; ipdb.set_trace()
+        blk.update(c)
+        self.assertEqual(blk.__basic__(), c)
+
+        t['properties']['attributes']['default'] = default
+        blk = load_block(t, 'type')
+        blk.name = 'name'
+        self.assertEqual(blk.__basic__(), c)
+
+    def test_load_list_str(self):
+        t = deepcopy(template)
+        t['properties']['attributes'] = {
+            'type': 'list',
+            'template': 'str'
+        }
+        blk = load_block(t, 'type')
+        blk.name = 'name'
+        c = deepcopy(config)
+        c['attributes'] = []
+        self.assertEqual(blk.__basic__(), c)
+        default = ['val1', 'val2']
+
+        c['attributes'].extend(default)
+        # make sure that the object updates properly
         blk.update(c)
         self.assertEqual(blk.__basic__(), c)
 


### PR DESCRIPTION
- template lists have another interesting feature where if they are a list of (say) strings, they don't have a type, but they **do** have `"template": "str"`
- added unit test to catch this