### PR TITLE
B/drop unknown

### DIFF
--- a/pynio/instance.py
+++ b/pynio/instance.py
@@ -91,8 +91,12 @@ class Instance(REST):
         blocks = {}
         for bname, config in self._get('blocks').items():
             btype = config['type']
-            b = blocks_types[btype].copy(bname, instance=self)
-            b.config = config
+            b = deepcopy(blocks_types[btype])
+            b._name = bname
+            b._instance = self
+            b._config.update(config, drop_unknown=True,
+                             drop_logger=self.droplog)
+            b._config['name'] = bname
             blocks[bname] = b
 
         return blocks_types, blocks

--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -32,7 +32,7 @@ class AttrDict(dict):
             if type(value) == dict:
                 dict.__setitem__(self, key, self.__class__(value))
 
-    def update(self, value):
+    def update(self, value, drop_unknown=False, drop_logger=None):
         '''Update self from a value dictionary.
 
         If values have their own `update` methods defined, values
@@ -41,9 +41,22 @@ class AttrDict(dict):
         '''
         if isinstance(value, dict):
             value = value.items()
+        if drop_unknown:
+            newv = {}
+            for key, value in value:
+                if key in self:
+                    newv[key] = value
+                else:
+                    if drop_logger is not None:
+                        drop_logger(key)
+            value = newv.items()
         for key, value in value:
             if hasattr(self[key], 'update'):
-                self[key].update(value)
+                try:
+                    self[key].update(value, drop_unknown=drop_unknown,
+                                            drop_logger=drop_logger)
+                except TypeError:
+                    self[key].update(value)
             else:
                 self[key] = value
 
@@ -193,27 +206,6 @@ class TypedDict(AttrDict):
         object.__setattr__(self, '_convert', convert)
         super().__init__(*args, **kwargs)
 
-    def update(self, value, drop_unknown=False, drop_logger=None):
-        '''Update the dictionary from a value
-
-        Arguments:
-            drop_unknown -- drop keys that are not in the dictionary
-                otherwise an error will be raised
-            drop_logger -- this will be called on each drop with the
-                key passed in. When drop_unknown evaluates to false it
-                does nothing
-        '''
-        if drop_unknown:
-            newv = {}
-            for key, value in value.items():
-                if key in self:
-                    newv[key] = value
-                else:
-                    if drop_logger is not None:
-                        drop_logger(key)
-            value = newv
-        return AttrDict.update(self, value)
-
     def _convert_value(self, value, curval):
         '''Convert value to type(curvalue). Also do associated error checking'''
         curtype = type(curval)
@@ -270,32 +262,35 @@ class TypedList(list):
             out.append(value)
         return out
 
-    def update(self, value):
+    def update(self, value, **kwargs):
         new = TypedList(self._type, value)  # check types
         self.clear()
         self.extend(new)
 
-    def _convert_value(self, value):
+    def _convert_value(self, value, **kwargs):
         '''Automatic type conversion. Uses update if it exists'''
         if hasattr(self._type, 'update'):
             # Copy our type (think of it is a template)
             _type = deepcopy(self._type)
             # update the values. Values not included will remain as the default
-            _type.update(value)
+            try:
+                _type.update(value, **kwargs)
+            except TypeError:
+                _type.update(value)
             value = _type
         elif not isinstance(value, type):
             return self._type(value)
         return value
 
-    def append(self, value):
+    def append(self, value, **kwargs):
         '''Append a value. It is type checked first'''
-        value = self._convert_value(value)
+        value = self._convert_value(value, **kwargs)
         list.append(self, value)
 
-    def extend(self, iterator):
+    def extend(self, iterator, **kwargs):
         '''Extend self from an iterator, type checking every value'''
         for i in iterator:
-            self.append(i)
+            self.append(i, **kwargs)
 
     def __setitem__(self, item, value):
         if self._noset:

--- a/pynio/properties.py
+++ b/pynio/properties.py
@@ -243,13 +243,15 @@ class TypedList(list):
         convert: whether to attempt automatic conversion to type
         noset: don't allow setting of existing elements
     '''
-    def __init__(self, type, *args, convert=True, noset=False, **kwargs):
+    def __init__(self, type, *args, convert=True, noset=False,
+                 drop_unknown=False, drop_logger=None, **kwargs):
         self._type = type
         self._convert = convert
         self._noset = noset
         list.__init__(self)  # make self an empty list
         convert = self._convert
-        self.extend(tuple(*args, **kwargs))
+        self.extend(tuple(*args, **kwargs), drop_unknown=drop_unknown,
+                    drop_logger=drop_logger)
 
     def __basic__(self):
         '''returns self in only basic python types.'''
@@ -263,9 +265,9 @@ class TypedList(list):
         return out
 
     def update(self, value, **kwargs):
-        new = TypedList(self._type, value)  # check types
+        new = TypedList(self._type, value, **kwargs)  # check types
         self.clear()
-        self.extend(new)
+        self.extend(new, **kwargs)
 
     def _convert_value(self, value, **kwargs):
         '''Automatic type conversion. Uses update if it exists'''

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -2,6 +2,7 @@ from enum import Enum
 from copy import copy, deepcopy
 
 import unittest
+from unittest.mock import MagicMock
 
 from .example_data import (SimulatorFastTemplate, SimulatorFastConfig,
                            SimulatorTemplate, SimulatorConfig)
@@ -230,3 +231,24 @@ class TestLoadProperties(unittest.TestCase):
         self.assertRaises(TypeError, setattr, blk.interval.days, 'bad')
         blk.log_level = 'DEBUG'
         self.assertRaises(ValueError, setattr, blk, 'log_level', 'bad')
+
+    def test_drop_unknown(self):
+        t = deepcopy(template)
+        t['properties']['attributes'] = {
+            'type': 'list',
+            'template': {
+                'name': {
+                    'type': 'str',
+                    'default': 'attrname'
+                },
+                'value': {
+                    'type': 'float',
+                    'default': 42.2
+                }
+            }
+        }
+        blk = load_block(t)
+        c = deepcopy(config)
+        c['attributes'] = [{'name': 'name', 'bad': 'foo', 'bad2': 'foo'}]
+        droplog = MagicMock()
+        blk.update(c, drop_unknown=True, drop_logger=droplog)


### PR DESCRIPTION
- drop unknown needs to propogate through all properties to load execc configs
- with this, #48 and #47 everything loads from all lab instances